### PR TITLE
新增多API的支持

### DIFF
--- a/main.py
+++ b/main.py
@@ -88,7 +88,7 @@ def translate_text(text, index, attempt=1):
 
     # 发送POST请求
     try:
-        response = requests.post(endpoint, json=data)
+        response = requests.post(endpoint[0], json=data)
         response.raise_for_status()
     except requests.RequestException as e:
         print(f'请求翻译API错误: {e}')
@@ -131,10 +131,11 @@ def init():
         config_data = {
             "last_processed": 0,
             "task_list": [],
-            "endpoint": "",
+            "endpoint": [],
             "api_type": 0,
             "save_frequency": 100,
-            "shutdown": 0
+            "shutdown": 0,
+            "max_workers": 1
         }
         with open("config.json", 'w') as file:
             json.dump(config_data, file, indent=4)
@@ -163,14 +164,14 @@ def init():
                 endpoint = "http://127.0.0.1:8080/completion"
             else:
                 endpoint = verurl
-            data['endpoint'] = endpoint
+            data['endpoint'].append(endpoint)
         elif api_type == 2:
             verurl = input("请输入Api地址(默认为http://127.0.0.1:5000/v1/completions):\n")
             if verurl == "" :
                 endpoint = "http://127.0.0.1:5000/v1/completions"
             else:
                 endpoint = verurl
-            data['endpoint'] = endpoint
+            data['endpoint'].append(endpoint)
         else :
             verurl = input("请输入Api地址(例如https://114-514-191-810.ngrok-free.app):\n")
             if verurl == "" :
@@ -178,7 +179,7 @@ def init():
                 sys.exit()
             else :
                 endpoint = verurl+"/v1/chat/completions"
-                data['endpoint'] = endpoint
+                data['endpoint'].append(endpoint)
         print("配置已保存到config.json,下次启动将默认加载")
     # 读取任务列表,保存频率,自动关机信息
     if task_list == []:

--- a/main.py
+++ b/main.py
@@ -88,7 +88,7 @@ def translate_text(text, index, attempt=1):
 
     # 发送POST请求
     try:
-        response = requests.post(endpoint[0], json=data)
+        response = requests.post(endpoint, json=data)
         response.raise_for_status()
     except requests.RequestException as e:
         print(f'请求翻译API错误: {e}')
@@ -131,11 +131,10 @@ def init():
         config_data = {
             "last_processed": 0,
             "task_list": [],
-            "endpoint": [],
+            "endpoint": "",
             "api_type": 0,
             "save_frequency": 100,
-            "shutdown": 0,
-            "max_workers": 1
+            "shutdown": 0
         }
         with open("config.json", 'w') as file:
             json.dump(config_data, file, indent=4)
@@ -164,14 +163,14 @@ def init():
                 endpoint = "http://127.0.0.1:8080/completion"
             else:
                 endpoint = verurl
-            data['endpoint'].append(endpoint)
+            data['endpoint'] = endpoint
         elif api_type == 2:
             verurl = input("请输入Api地址(默认为http://127.0.0.1:5000/v1/completions):\n")
             if verurl == "" :
                 endpoint = "http://127.0.0.1:5000/v1/completions"
             else:
                 endpoint = verurl
-            data['endpoint'].append(endpoint)
+            data['endpoint'] = endpoint
         else :
             verurl = input("请输入Api地址(例如https://114-514-191-810.ngrok-free.app):\n")
             if verurl == "" :
@@ -179,7 +178,7 @@ def init():
                 sys.exit()
             else :
                 endpoint = verurl+"/v1/chat/completions"
-                data['endpoint'].append(endpoint)
+                data['endpoint'] = endpoint
         print("配置已保存到config.json,下次启动将默认加载")
     # 读取任务列表,保存频率,自动关机信息
     if task_list == []:

--- a/main.py
+++ b/main.py
@@ -88,7 +88,7 @@ def translate_text(text, index, attempt=1):
 
     # 发送POST请求
     try:
-        response = requests.post(endpoint, json=data)
+        response = requests.post(endpoint[0], json=data)
         response.raise_for_status()
     except requests.RequestException as e:
         print(f'请求翻译API错误: {e}')
@@ -131,10 +131,12 @@ def init():
         config_data = {
             "last_processed": 0,
             "task_list": [],
-            "endpoint": "",
+            "endpoint": [],
             "api_type": 0,
             "save_frequency": 100,
-            "shutdown": 0
+            "shutdown": 0,
+            "max_workers": 1,
+            "use_lock": 0
         }
         with open("config.json", 'w') as file:
             json.dump(config_data, file, indent=4)
@@ -149,7 +151,7 @@ def init():
     task_list = data['task_list']
     start_index = data['last_processed']
     # 读取api信息
-    if endpoint == '':
+    if endpoint == []:
         veri = input("请输入数字来选择部署类型(默认为本地部署):\n[0] 本地部署Sakura v0.9\n[1] kaggle部署Sakura v0.9 \n[2]text-generation-webui\n")
         if veri == "" :
             api_type = 0
@@ -163,14 +165,14 @@ def init():
                 endpoint = "http://127.0.0.1:8080/completion"
             else:
                 endpoint = verurl
-            data['endpoint'] = endpoint
+            data['endpoint'].append(endpoint)
         elif api_type == 2:
             verurl = input("请输入Api地址(默认为http://127.0.0.1:5000/v1/completions):\n")
             if verurl == "" :
                 endpoint = "http://127.0.0.1:5000/v1/completions"
             else:
                 endpoint = verurl
-            data['endpoint'] = endpoint
+            data['endpoint'].append(endpoint)
         else :
             verurl = input("请输入Api地址(例如https://114-514-191-810.ngrok-free.app):\n")
             if verurl == "" :
@@ -178,7 +180,7 @@ def init():
                 sys.exit()
             else :
                 endpoint = verurl+"/v1/chat/completions"
-                data['endpoint'] = endpoint
+                data['endpoint'].append(endpoint)
         print("配置已保存到config.json,下次启动将默认加载")
     # 读取任务列表,保存频率,自动关机信息
     if task_list == []:

--- a/main.py
+++ b/main.py
@@ -226,6 +226,12 @@ def shutdown_pc():
     else:
         os.system('shutdown -h 1')
 
+def save_json_safely(data, task_name):
+    temp_task_name = task_name + '.tmp'
+    with open(temp_task_name, 'w', encoding='utf-8') as file:
+        json.dump(data, file, ensure_ascii=False, indent=4)
+    os.replace(temp_task_name, task_name)  # 替换原文件
+
 def main():
     init()              
     while task_list != []:
@@ -256,13 +262,15 @@ def main():
             if (i + 1) % save_frequency == 0:
                 print(f"达到{save_frequency}行，保存进度和文件...")
                 save_progress(i + 1,task_list)
-                with open(task_name, 'w', encoding='utf-8') as file:
-                    json.dump(data, file, ensure_ascii=False, indent=4)
+                # with open(task_name, 'w', encoding='utf-8') as file:
+                #     json.dump(data, file, ensure_ascii=False, indent=4)
+                save_json_safely(data, task_name)
                 print("保存完成.")
         task_list.pop(0)
         save_progress(0,task_list)
-        with open(task_name, 'w', encoding='utf-8') as file:
-            json.dump(data, file, ensure_ascii=False, indent=4)
+        # with open(task_name, 'w', encoding='utf-8') as file:
+        #     json.dump(data, file, ensure_ascii=False, indent=4)
+        save_json_safely(data, task_name)
         print(f"文件{task_name}翻译完成.")
         
     # 翻译完成后进度重置

--- a/main_dev.py
+++ b/main_dev.py
@@ -9,6 +9,7 @@ import unicodedata
 import time
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
+import threading
 
 def contains_japanese(text):
     # 将文本中的半角假名转换为全角假名
@@ -27,7 +28,7 @@ def split_text_with_newlines(text):
     paragraphs = re.split(r'(\r\n|\r|\n)', text)
     return paragraphs
 
-def translate_text_by_paragraph(text, index):
+def translate_text_by_paragraph(text, index, api_idx = 0):
     #检查是否包含日文，并将半角假名转换为全角假名
     contains_jp, updated_text = contains_japanese(text)
 
@@ -43,19 +44,19 @@ def translate_text_by_paragraph(text, index):
             else:
                 # 如果段落不是换行符，则进行翻译
                 if segment:  # 避免翻译空段落
-                    translated_segments.append(translate_text(segment, index))
+                    translated_segments.append(translate_text(segment, index, api_idx=api_idx))
                 else:
                     translated_segments.append(segment)
         # 将翻译后的段落和换行符重新组合成完整的文本
         translated_text = ''.join(translated_segments)
-        print(f"索引：第{index}行|原文: {text} => 翻译: {translated_text}\n\n")
+        print(f"api{api_idx} 索引：第{index}行|原文: {text} => 翻译: {translated_text}\n\n")
         return translated_text
     
     else:
         print(f"索引：第{index}行|原文: {text} 不包含日文，跳过\n\n")
         return text
 
-def translate_text(text, index, attempt=1):
+def translate_text(text, index, attempt=1, api_idx = 0):
     if attempt > 3:
         # 如果重试次数超过3次，跳过这一行
         log_repetitive(index)
@@ -96,7 +97,7 @@ def translate_text(text, index, attempt=1):
 
     # 发送POST请求
     try:
-        response = requests.post(endpoint, json=data)
+        response = requests.post(endpoint[api_idx], json=data)
         response.raise_for_status()
     except requests.RequestException as e:
         print(f'请求翻译API错误: {e}')
@@ -128,16 +129,17 @@ def init():
         config_data = {
             "last_processed": 0,
             "task_list": [],
-            "endpoint": "",
+            "endpoint": [],
             "api_type": 0,
             "save_frequency": 100,
             "shutdown": 0,
-            "max_workers": 1
+            "max_workers": 1,
+            "use_lock": 0,
         }
         with open("config.json", 'w') as file:
             json.dump(config_data, file, indent=4)
     # 读取配置文件
-    global api_type, endpoint, save_frequency, shutdown, task_list, start_index, max_workers
+    global api_type, endpoint, save_frequency, shutdown, task_list, start_index, max_workers, use_lock
     with open('config.json', 'r', encoding='utf-8') as file:
         data=json.load(file)
     endpoint = data['endpoint']
@@ -147,8 +149,9 @@ def init():
     task_list = data['task_list']
     start_index = data['last_processed']
     max_workers = data['max_workers']
+    use_lock = data['use_lock']
     # 读取api信息
-    if endpoint == '':
+    if endpoint == []:
         veri = input("请输入数字来选择部署类型(默认为本地部署):\n[0] 本地部署Sakura v0.9\n[1] kaggle部署Sakura v0.9 \n[2]text-generation-webui\n")
         if veri == "" :
             api_type = 0
@@ -156,28 +159,42 @@ def init():
             api_type = int(veri)
         data['api_type'] = api_type
 
-        if api_type == 0 :
-            verurl = input("请输入Api地址(默认为http://127.0.0.1:8080/completion):\n")
-            if verurl == "" :
-                endpoint = "http://127.0.0.1:8080/completion"
+        if(api_type == 0 or api_type == 2):
+            veri = int(input("API启用数量(默认为1):\n"))
+            if veri == "" :
+                api_num = 1
             else:
-                endpoint = verurl
-            data['endpoint'] = endpoint
-        elif api_type == 2:
-            verurl = input("请输入Api地址(默认为http://127.0.0.1:5000/v1/completions):\n")
-            if verurl == "" :
-                endpoint = "http://127.0.0.1:5000/v1/completions"
-            else:
-                endpoint = verurl
-            data['endpoint'] = endpoint
-        else :
-            verurl = input("请输入Api地址(例如https://114-514-191-810.ngrok-free.app):\n")
-            if verurl == "" :
-                print("必须提供Api地址！")
-                sys.exit()
+                api_num = veri
+        for i in range(api_num):
+            if api_type == 0 :
+                verurl = input("请输入Api地址(默认为http://127.0.0.1:8080/completion):\n")
+                if verurl == "" :
+                    endpoint = "http://127.0.0.1:8080/completion"
+                else:
+                    endpoint = verurl
+                data['endpoint'].append(endpoint)
+            elif api_type == 2:
+                verurl = input("请输入Api地址(默认为http://127.0.0.1:5000/v1/completions):\n")
+                if verurl == "" :
+                    endpoint = "http://127.0.0.1:5000/v1/completions"
+                else:
+                    endpoint = verurl
+                data['endpoint'].append(endpoint)
             else :
-                endpoint = verurl+"/v1/chat/completions"
-                data['endpoint'] = endpoint
+                verurl = input("请输入Api地址(例如https://114-514-191-810.ngrok-free.app):\n")
+                if verurl == "" :
+                    print("必须提供Api地址！")
+                    sys.exit()
+                else :
+                    endpoint = verurl+"/v1/chat/completions"
+                    data['endpoint'].append(endpoint)
+        if(api_type > 1):
+            veri = input("是否让每一个API一次只进行一个翻译？(默认为0):\n[0] 否，一个API同时进行多个翻译\n[1] 是\n")
+            if veri == "" :
+                use_lock = 0
+            else:
+                use_lock = int(veri)
+            data['use_lock'] = use_lock
         print("配置已保存到config.json,下次启动将默认加载")
     # 读取任务列表,保存频率,自动关机信息
     if task_list == []:
@@ -243,15 +260,17 @@ def save_progress(data, filename, index, task_list):
         file.truncate()
 
 def main():
-    init()              
-    while task_list != []:
-        # 读取JSON文件
+    global semaphores
+    init()
+    while task_list:
         task_name = task_list[0]
         print(f"正在读取文件...")
         with open(task_name, 'r', encoding='utf-8') as file:
             data = json.load(file)
         print("读取完成.")
 
+        api_num = len(endpoint)
+        semaphores = [threading.Semaphore(1) for _ in endpoint]
         keys = list(data.keys())
         
         total_keys = len(keys)
@@ -261,8 +280,14 @@ def main():
 
         # 创建线程池
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            # 提交翻译任务
-            future_to_key = {executor.submit(translate_text_by_paragraph, data[key], i): key for i, key in enumerate(keys[start_from:], start=start_from)}
+            future_to_key = {}
+            for i, key in enumerate(keys[start_from:], start=start_from):
+                api_index = i % api_num
+                semaphore = semaphores[api_index] if use_lock else None
+                
+                # 使用信号量来确保每个API同一时刻只处理一个任务
+                future = executor.submit(api_task_wrapper, semaphore, translate_text_by_paragraph, data[key], i, api_index)
+                future_to_key[future] = key
 
             # 创建进度条
             for future in tqdm(as_completed(future_to_key), total=len(future_to_key), desc="任务进度"):
@@ -288,6 +313,13 @@ def main():
     if shutdown == 1:
         print("翻译完成，将在一分钟后关机...")
         shutdown_pc()
+
+def api_task_wrapper(semaphore, func, *args):
+    if semaphore:
+        with semaphore:
+            return func(*args)
+    else:
+        return func(*args)
 
 if __name__ == "__main__":
     main()

--- a/main_dev.py
+++ b/main_dev.py
@@ -249,8 +249,9 @@ def shutdown_pc():
 
 def save_progress(data, filename, index, task_list):
     # 保存当前的进度
-    with open(filename, 'w', encoding='utf-8') as file:
-        json.dump(data, file, ensure_ascii=False, indent=4)
+    save_json_safely(data, filename)
+    # with open(filename, 'w', encoding='utf-8') as file:
+        # json.dump(data, file, ensure_ascii=False, indent=4)
     with open('config.json', 'r+', encoding='utf-8') as file:
         config_data = json.load(file)
         config_data['last_processed'] = index
@@ -258,6 +259,12 @@ def save_progress(data, filename, index, task_list):
         file.seek(0)
         json.dump(config_data, file, indent=4)
         file.truncate()
+
+def save_json_safely(data, task_name):
+    temp_task_name = task_name + '.tmp'
+    with open(temp_task_name, 'w', encoding='utf-8') as file:
+        json.dump(data, file, ensure_ascii=False, indent=4)
+    os.replace(temp_task_name, task_name)  # 替换原文件
 
 def main():
     global semaphores

--- a/main_dev.py
+++ b/main_dev.py
@@ -27,7 +27,7 @@ def split_text_with_newlines(text):
     paragraphs = re.split(r'(\r\n|\r|\n)', text)
     return paragraphs
 
-def translate_text_by_paragraph(text, index):
+def translate_text_by_paragraph(text, index, api_idx=0):
     #检查是否包含日文，并将半角假名转换为全角假名
     contains_jp, updated_text = contains_japanese(text)
 
@@ -43,7 +43,7 @@ def translate_text_by_paragraph(text, index):
             else:
                 # 如果段落不是换行符，则进行翻译
                 if segment:  # 避免翻译空段落
-                    translated_segments.append(translate_text(segment, index))
+                    translated_segments.append(translate_text(segment, index, api_idx=api_idx))
                 else:
                     translated_segments.append(segment)
         # 将翻译后的段落和换行符重新组合成完整的文本
@@ -55,7 +55,7 @@ def translate_text_by_paragraph(text, index):
         print(f"索引：第{index}行|原文: {text} 不包含日文，跳过\n\n")
         return text
 
-def translate_text(text, index, attempt=1):
+def translate_text(text, index, attempt=1, api_idx=0):
     if attempt > 3:
         # 如果重试次数超过3次，跳过这一行
         log_repetitive(index)
@@ -96,7 +96,7 @@ def translate_text(text, index, attempt=1):
 
     # 发送POST请求
     try:
-        response = requests.post(endpoint, json=data)
+        response = requests.post(endpoint[api_idx], json=data)
         response.raise_for_status()
     except requests.RequestException as e:
         print(f'请求翻译API错误: {e}')
@@ -128,7 +128,7 @@ def init():
         config_data = {
             "last_processed": 0,
             "task_list": [],
-            "endpoint": "",
+            "endpoint": [],
             "api_type": 0,
             "save_frequency": 100,
             "shutdown": 0,
@@ -148,36 +148,38 @@ def init():
     start_index = data['last_processed']
     max_workers = data['max_workers']
     # 读取api信息
-    if endpoint == '':
-        veri = input("请输入数字来选择部署类型(默认为本地部署):\n[0] 本地部署Sakura v0.9\n[1] kaggle部署Sakura v0.9 \n[2]text-generation-webui\n")
+    if endpoint == []:
+        veri = input("请输入数字来选择部署类型(默认为本地部署):\n[0] 本地部署Sakura v0.9\n[1] kaggle部署Sakura v0.9 \n[2] text-generation-webui\n")
         if veri == "" :
             api_type = 0
         else:
             api_type = int(veri)
         data['api_type'] = api_type
-
-        if api_type == 0 :
-            verurl = input("请输入Api地址(默认为http://127.0.0.1:8080/completion):\n")
-            if verurl == "" :
-                endpoint = "http://127.0.0.1:8080/completion"
-            else:
-                endpoint = verurl
-            data['endpoint'] = endpoint
-        elif api_type == 2:
-            verurl = input("请输入Api地址(默认为http://127.0.0.1:5000/v1/completions):\n")
-            if verurl == "" :
-                endpoint = "http://127.0.0.1:5000/v1/completions"
-            else:
-                endpoint = verurl
-            data['endpoint'] = endpoint
-        else :
-            verurl = input("请输入Api地址(例如https://114-514-191-810.ngrok-free.app):\n")
-            if verurl == "" :
-                print("必须提供Api地址！")
-                sys.exit()
-            else :
-                endpoint = verurl+"/v1/chat/completions"
+        if(api_type == 0 or api_type == 2):
+            api_num = input("输入同时使用的API数量？(默认为1)\n")
+        for i in range(1, int(api_num)+1):
+            if api_type == 0 :
+                verurl = input(f"请输入第{i}个Api地址(默认为http://127.0.0.1:8080/completion):\n")
+                if verurl == "" :
+                    endpoint.append("http://127.0.0.1:8080/completion")
+                else:
+                    endpoint.append(verurl)
                 data['endpoint'] = endpoint
+            elif api_type == 2:
+                verurl = input(f"请输入第{i}个Api地址(默认为http://127.0.0.1:5000/v1/completions):\n")
+                if verurl == "" :
+                    endpoint.append("http://127.0.0.1:5000/v1/completions")
+                else:
+                    endpoint.append(verurl)
+                data['endpoint'] = endpoint
+            else :
+                verurl = input(f"请输入第{i}个Api地址(例如https://114-514-191-810.ngrok-free.app):\n")
+                if verurl == "" :
+                    print("必须提供Api地址！")
+                    sys.exit()
+                else :
+                    endpoint.append(verurl+"/v1/chat/completions")
+                    data['endpoint'] = endpoint
         print("配置已保存到config.json,下次启动将默认加载")
     # 读取任务列表,保存频率,自动关机信息
     if task_list == []:
@@ -251,7 +253,7 @@ def main():
         with open(task_name, 'r', encoding='utf-8') as file:
             data = json.load(file)
         print("读取完成.")
-
+        api_num = len(endpoint)
         keys = list(data.keys())
         
         total_keys = len(keys)
@@ -262,7 +264,12 @@ def main():
         # 创建线程池
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             # 提交翻译任务
-            future_to_key = {executor.submit(translate_text_by_paragraph, data[key], i): key for i, key in enumerate(keys[start_from:], start=start_from)}
+            # future_to_key = {executor.submit(translate_text_by_paragraph, data[key], i): key for i, key in enumerate(keys[start_from:], start=start_from)}
+            future_to_key = {
+                executor.submit(translate_text_by_paragraph, data[key], i, i % api_num,): key
+                for i, key in enumerate(keys[start_from:], start=start_from)
+            }
+
 
             # 创建进度条
             for future in tqdm(as_completed(future_to_key), total=len(future_to_key), desc="任务进度"):


### PR DESCRIPTION
1. main_dev中利用多线程同时调用多组API，方便多API/多GPU用户加速翻译
2. API可能不支持同时处理多个请求，另设进程锁设置，开启后能保证单个API一次只会进行一组翻译
3. 原本的翻译结果保存方式不够安全，保存时意外中断脚本会导致原始数据丢失。优化策略是保存临时文件，再替换原始文件。
4. 统一了main和main_dev的config格式